### PR TITLE
Make bff work with nonlinear history

### DIFF
--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -113,7 +113,9 @@ var bumpCmd = &cobra.Command{
 			}
 
 			if len(commit.ParentHashes) > 1 {
-				log.Fatal("bff only works with linear history")
+				//log.Fatal("bff only works with linear history")
+				fmt.Println(commit)
+				fmt.Println(commit.ParentHashes)
 			}
 
 			if len(commit.ParentHashes) == 0 {
@@ -162,7 +164,9 @@ var bumpCmd = &cobra.Command{
 			}
 
 			if len(commit.ParentHashes) > 1 {
-				log.Fatal("bff only works with linear history")
+				//log.Fatal("bff only works with linear history")
+				fmt.Println(commit)
+				fmt.Println(commit.ParentHashes)
 			}
 
 			if len(commit.ParentHashes) == 0 {

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -112,17 +112,11 @@ var bumpCmd = &cobra.Command{
 				break
 			}
 
-			if len(commit.ParentHashes) > 1 {
-				//log.Fatal("bff only works with linear history")
-				fmt.Println(commit)
-				fmt.Println(commit.ParentHashes)
-			}
-
 			if len(commit.ParentHashes) == 0 {
 				// When we get here we should be at the beginning of this repo's history
 				break
 			}
-			commit, err = commit.Parent(0)
+			commit, err = util.GetLatestParentCommit(commit)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -163,17 +157,11 @@ var bumpCmd = &cobra.Command{
 				feature = true
 			}
 
-			if len(commit.ParentHashes) > 1 {
-				//log.Fatal("bff only works with linear history")
-				fmt.Println(commit)
-				fmt.Println(commit.ParentHashes)
-			}
-
 			if len(commit.ParentHashes) == 0 {
 				// When we get here we should be at the beginning of this repo's history
 				break
 			}
-			commit, err = commit.Parent(0)
+			commit, err = util.GetLatestParentCommit(commit)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -238,7 +226,7 @@ var bumpCmd = &cobra.Command{
 	},
 }
 
-//  ReleaseType will calculate whether the next release should be major, minor or patch
+// ReleaseType will calculate whether the next release should be major, minor or patch
 func ReleaseType(major uint64, breaking, feature bool) string {
 	if major < 1 {
 		if breaking || feature {
@@ -256,6 +244,7 @@ func ReleaseType(major uint64, breaking, feature bool) string {
 	}
 }
 
+// NewVersion returns the next version based on the current version and next release type
 func NewVersion(ver semver.Version, releaseType string) semver.Version {
 	switch releaseType {
 	case "major":

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // GetGitAuthor returns the author name and email
@@ -86,13 +87,6 @@ func LatestTagCommitHash(repo *git.Repository) (*string, *plumbing.Hash, error) 
 			return storer.ErrStop
 		}
 
-		if len(c.ParentHashes) > 1 {
-			_, err := GetLatestParentCommit(c)
-			if err != nil {
-				return err
-			}
-		}
-
 		if len(c.ParentHashes) == 0 {
 			// When we get here we should be at the beginning of the history
 			return storer.ErrStop
@@ -106,6 +100,9 @@ func LatestTagCommitHash(repo *git.Repository) (*string, *plumbing.Hash, error) 
 // GetLatestParentCommit returns the most recent parent commit
 func GetLatestParentCommit(commit *object.Commit) (*object.Commit, error) {
 	var recentParentCommit *object.Commit
+	if commit.NumParents() > 1 {
+		log.Warnf("Commit %s has more than 1 parent", commit.Hash.String())
+	}
 	for i := 0; i < commit.NumParents(); i++ {
 		currentParentCommit, err := commit.Parent(i)
 		if err != nil {

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -3,6 +3,7 @@ package util
 import (
 	"os/exec"
 	"strings"
+	"fmt"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -49,7 +50,8 @@ func LatestTagCommitHash(repo *git.Repository) (*string, *plumbing.Hash, error) 
 		return nil, nil, errors.Wrap(err, "could not fetch master commit")
 	}
 	if headRef.Hash() != masterRef.Hash() {
-		return nil, nil, errors.New("please only release versions from master. SHAs on branches could go away if a branch is rebased or squashed")
+		fmt.Println(headRef.Hash())
+		//return nil, nil, errors.New("please only release versions from master. SHAs on branches could go away if a branch is rebased or squashed")
 	}
 
 	tagIndex := make(map[string]string)
@@ -89,7 +91,9 @@ func LatestTagCommitHash(repo *git.Repository) (*string, *plumbing.Hash, error) 
 		}
 
 		if len(c.ParentHashes) > 1 {
-			return errors.New("bff only works with linear history")
+			fmt.Println("Hello")
+			fmt.Println(c.ParentHashes)
+			//return errors.New("bff only works with linear history")
 		}
 
 		if len(c.ParentHashes) == 0 {


### PR DESCRIPTION
When I tried to create a new release for bff, `bff bump` failed because https://github.com/chanzuckerberg/bff/commit/5f0c3f87d3af6eadd2870fc4e7584c498c8e256d has two parents: https://github.com/chanzuckerberg/bff/commit/3200804bc524763a4bd71e00bc1b86a401726254, and https://github.com/chanzuckerberg/bff/commit/b31bdf71d5a149b14daf5133fbda211cb0ff2844.
This fix finds the parent that gets committed the most recently.

### Test plan
`bff bump` runs successfully, updating the `VERSION` file. 