### PR TITLE
reviewdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ coverage.txt
 bff
 .vscode
 dist
-vendor/gopkg.in/src-d/go-billy.v4/go.sum
+vendor/gopkg.in/src-d/go-billy.v4/go.sumbin

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ coverage.txt
 bff
 .vscode
 dist
-vendor/gopkg.in/src-d/go-billy.v4/go.sumbin
+bin

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,0 +1,8 @@
+runner:
+  golangci:
+    cmd: ./bin/golangci-lint run --out-format=line-number
+    errorformat:
+      - '%E%f:%l:%c: %m'
+      - '%E%f:%l: %m'
+      - '%C%.%#'
+    level: warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,20 @@ go:
   - "1.13.1"
 install:
   - npm install -g snyk
+  - make setup
 jobs:
   include:
-    - stage: check
+    - name: lint
+      stage: check
+      script: make lint-ci
+    - name: test
+      stage: check
       script:
         - make test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
-    - stage: check
+    - name: snyk
+      stage: check
       script:
         - snyk monitor --org=czi
         - snyk test

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,25 @@ export GO111MODULE=on
 
 all: test
 .PHONY: all
-	
+
+setup: ## setup development dependencies
+	curl -sfL https://raw.githubusercontent.com/chanzuckerberg/bff/master/download.sh | sh
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
+.PHONY: setup
+
 lint: ## run the fast go linters
-	gometalinter --vendor --fast ./...
+	./bin/reviewdog -conf .reviewdog.yml  -diff "git diff master"
 .PHONY: lint
 
-lint-slow: ## run all linters, even the slow ones
-	gometalinter --vendor --deadline 120s ./...
-.PHONY: lint-slow
+lint-ci: ## run the fast go linters
+	./bin/reviewdog -conf .reviewdog.yml  -reporter=github-pr-review
+.PHONY: lint-ci
+
+lint-all: ## run the fast go linters
+	# doesn't seem to be a way to get reviewdog to not filter by diff
+	golangci-lint run
+.PHONY: lint-all
 
 release: build ## run a release
 	./bff bump


### PR DESCRIPTION
This adds [reviewdog](https://github.com/reviewdog/reviewdog) as a way to integrate linting with pull requests.

Already in use on [fogg](https://github.com/chanzuckerberg/fogg).