### PR TITLE
[fix] ignore tags that are not semver

### DIFF
--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -86,7 +86,13 @@ var bumpCmd = &cobra.Command{
 		}
 
 		tags.ForEach(func(tag *plumbing.Reference) error {
-			tagIndex[tag.Hash().String()] = strings.Replace(tag.Name().String(), "refs/tags/v", "", -1)
+			str := strings.Replace(tag.Name().String(), "refs/tags/v", "", -1)
+			_, err := semver.Parse(str)
+			if err != nil {
+				fmt.Printf("Error parsing version %s\n", str)
+			} else {
+				tagIndex[tag.Hash().String()] = str
+			}
 			return nil
 		})
 


### PR DESCRIPTION
This should–

1. ignore pre-release's because the semver parser doesn't recognize it as a valid semver version
2. ignore tags that are not related to releasese.